### PR TITLE
docs: add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Valor is a tool that can be used to validate and evaluate resource.
 
 ### 1. Clone Repo
 
-Clone this repository into your local by running the following command:
+Clone this repository into the local by running the following command:
 
 ```zsh
 git clone github.com/gojek/optimus-extension-valor
@@ -16,77 +16,91 @@ git clone github.com/gojek/optimus-extension-valor
 
 ### 2. Create Recipe
 
-Create a recipe named `valor.yaml` or rename the recipe file in
-this project directory from `valor.example.yaml` into `valor.yaml`.
-The content of the recipe should look like the following.
-Assets referred by the specified recipe are available under `./example` directory.
+Copy the recipe example `valor.example.yaml` to `valor.yaml`. The resource that will be validated and evaluated from the recipe is like the following:
 
 ```yaml
-resources: 
+resources:
 - name: user_account
-  type: file
-  path: ./example/resource/user_account.json
+  type: dir
+  path: ./example/resource
   format: json
   framework_names:
-  - user_account_validation
-
-frameworks:
-- name: user_account_validation
-  schemas:
-  - name: user_account_rule
-    type: file
-    format: json
-    path: ./example/schema/user_account_rule.json
-  procedures:
-  - name: enrich_user_account
-    type: file
-    format: jsonnet
-    path: ./example/procedure/enrich_user_account.jsonnet
-  output_targets:
-  - name: std_output
-    type: std
-    format: json
+  - user_account_evaluation
+...
 ```
 
-In this example, Resource named `user_account` will be evaluated agaist
-framework named `user_account_validation`. The targetted framework
-specifies three things:
+As stated in the recipe, the resource is available under directory `./example/resource`. One example of the resource is like the following:
 
-* Schema, which follows JSON schema format to validate the Resource. It is
-required to validate whether the structure for the `user_account`
-Resource contains error or not.
-* Procedure, which follows JSONNET format to evaluate the `user_account` Resource.
-It can be for validation or any execution that can't be handled by
-using Schema.
-* Output Target, which specifies on how to write the output of either Schema or
-Procedure or both.
+```json
+{
+    "email": "valor@github.com",
+    "membership_id": 1,
+    "is_active": true
+}
+```
 
-### 3. Execute Pipeline
+Note that the `membership_id` is in numeric.
 
-After the preparation is done, try running valor by executing the following
-command:
+### 3. Prepare Valor
+
+To execute the pipeline, one can either:
+
+* download the latest binary from [here](https://github.com/gojek/optimus-extension-valor/releases) and put it in this project directory, or
+* try building it by following [this guide](#how-to-build)
+
+### 4. Execute Pipeline
+
+After the preparation is done, try executing Valor from the CLI like the following:
 
 ```zsh
 ./out/valor execute
 ```
 
-Or, if you have not build it, try building it by following [#HowToBuild](#how-to-build).
-Make sure to have the required dependencies specified under [#Dependency](#dependency).
-The output of the above solution should look like the following:
+And done. Based on the recipe, the output will be printed to the std out, or in other words in the CLI. The output should contain one of the modified input, like the following:
 
 ```zsh
-user_account: ./example/resource/user_account.json
+...
 {
    "email": "valor@github.com",
    "is_active": true,
-   "is_valid": true,
    "membership": "premium"
 }
+...
 ```
 
-## Dependency
+### 5. Explanation
 
-### GO Language
+What Valor does is actually stated in the recipe file `valor.yaml`. Behind the scene, the process is like the following:
+
+1. read the first resource
+2. execute framework pointed by field `framework_names`
+3. in the framework, run validation based on `schemas`
+4. if no error is found, load the required definition under `definitions`
+5. if no error is found, execute proceduresstated under `procedures`
+6. if no error is found, write the result based on `output_targets`
+
+The explanation here is quite brief. For further explanation, try checkout the documentation [here](#documentation).
+
+## Documentation
+
+The complete documentation is available like the following:
+
+* [recipe](./docs/recipe.md)
+
+## Development
+
+Community contribution is very welcome. Though, because of diverse background, one might not be able to easily understand the reasoning behind every decision or approach. So, the following is the general guideline to contribute:
+
+1. create a dedicated branch
+2. after all changes are done, create a PR
+3. in that PR, please describes the issue or reasining or even approach for such changes
+4. if no issue is found, merge will be done shortly
+
+In order to follow the above steps, one might need to setup the local environment. The following is the general information to set it up.
+
+### Dependency
+
+#### GO Language
 
 The GO programming language version `go1.17.1` need to be installed
 in the system. Go to [this link](https://golang.org/doc/install) and follow
@@ -102,7 +116,7 @@ example output:
 go version go1.17.1 darwin/amd64
 ```
 
-## How to Test
+#### How to Test
 
 In this project root directory, run the following command to test:
 
@@ -117,9 +131,9 @@ make coverage
 ```
 
 You can check into `coverage.html` file in root project directory.
-This command also will open interactive coverage tool in your browser if you have one.
+This command also will open interactive coverage tool in the browser.
 
-## How to Build
+#### How to Build
 
 To build the binary executable, in this project root directory, run the following command:
 
@@ -137,7 +151,7 @@ make dist
 
 There will be a new directory named `dist` with few executable files.
 
-## How to Run
+#### How to Run
 
 In order to run this project, after building the binary executable, run
 the following command in this project root directory:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ The explanation here is quite brief. For further explanation, try checkout the d
 
 The complete documentation is available like the following:
 
-* [recipe](./docs/recipe.md)
+* [recipe](./docs/recipe.md), which explains more about recipe and how to set it up for execution
+* [command](./docs/command.md), which explains more about the available commands to be run
 
 ## Development
 

--- a/docs/command.md
+++ b/docs/command.md
@@ -1,0 +1,101 @@
+# Command
+
+## Description
+
+This documentation explains more about the available commands in Valor.
+Assuming Valor is already built (see [here](../README.md#how-to-run)), then when the user run the command:
+
+```zsh
+./out/valor
+```
+
+The following output will be shown in CLI:
+
+```zsh
+Usage:
+  valor [command]
+
+Available Commands:
+  completion  generate the autocompletion script for the specified shell
+  execute     Execute pipeline based on the specified recipe
+  help        Help about any command
+  profile     Profile the recipe specified by path
+
+Flags:
+  -h, --help   help for valor
+
+Use "valor [command] --help" for more information about a command.
+```
+
+## Profile
+
+Profile is a command that will profile the specified Valor recipe. By default, the recipe being profiled is read from `valor.yaml` in the active directory. Like the following example:
+
+```zsh
+./out/valor profile
+```
+
+If the recipe from the provided example `valor.example.yaml` is copied into `valor.yaml`, then the output will be like the following:
+
+```zsh
+RESOURCE:
++--------------+--------+------+--------------------+-------------------------+
+|     NAME     | FORMAT | TYPE |        PATH        |        FRAMEWORK        |
++--------------+--------+------+--------------------+-------------------------+
+| user_account | json   | dir  | ./example/resource | user_account_evaluation |
++--------------+--------+------+--------------------+-------------------------+
+
+FRAMEWORK:
++-------------------------+------------+---------------------+
+|        FRAMEWORK        |    TYPE    |        NAME         |
++-------------------------+------------+---------------------+
+| user_account_evaluation | definition | memberships         |
++                         +------------+---------------------+
+|                         | schema     | user_account_rule   |
++                         +------------+---------------------+
+|                         | procedure  | enrich_user_account |
++                         +------------+---------------------+
+|                         | output     | std_output          |
++-------------------------+------------+---------------------+
+```
+
+The user can also specify other recipe by using flag `--recipe-path` like the following:
+
+```zsh
+./out/valor profile --recipe-path=valor.example.yaml
+```
+
+## Execute
+
+Execute is a command that execute pipeline based on the provided recipe. By default, the recipe being executed is read from `valor.yaml` in the active directory. An example of running this command:
+
+```zsh
+./out/valor execute
+```
+
+Running the above command will execute all frameworks under `valor.yaml` recipe. This command also has several flags.
+
+Flag | Description | Format
+--- | --- | ---
+--batch-size | specify the number of data to be executed paralelly in one batch | it should be an integer more than 0 (zero). it is optional with default value 4 (four).
+--progress-type | specify the progress type during execution | currently available: `verbose` (default) and `simple`
+--recipe-path | customize the recipe that will be executed | it is optional. the value should be a valid recipe path
+
+This command also has sub-command. The currently available sub-commands are explained below.
+
+### Resource
+
+Recipe is required in every execution. However, sometime the user just want a certain resource to executed. The user can define a new recipe to accomplish such requirement. Or, another alternative is by using resource sub-command. Resource sub-command is a command that allows the user to specify which resource to be executed. So, with he same recipe, the user can select the only resource they need to be executed. To use this sub-command, run it like the following:
+
+```zsh
+./out/valor execute resource
+```
+
+This sub-command inherit the flags from the execute command. In addition to that, it also has its own flags like the following.
+
+Flag | Description | Format
+--- | --- | ---
+--name | the name of the resource to be executed | it is mandatory and should refer to the resource in the recipe
+--format | the format of the input resource | if it's not specified, Valor will use the format in recipe. but if it is, then Valor will use it instead.
+--path | the path of the input resource | if it's not specified, Valor will use the format in recipe. but if it is, then Valor will use it instead.
+--type | the type of path for the specified resource | if it's not specified, Valor will use the format in recipe. but if it is, then Valor will use it instead.

--- a/docs/recipe.md
+++ b/docs/recipe.md
@@ -11,13 +11,13 @@ Resource is something to be either validated, evaluated, or both.
 Each recipe should contains one or more resources. An example:
 
 ```yaml
-resources: 
+resources:
 - name: user_account
-  type: file
-  path: ./example/resource/user_account.json
+  type: dir
+  path: ./example/resource
   format: json
   framework_names:
-  - user_account_validation
+  - user_account_evaluation
 ...
 ```
 
@@ -43,7 +43,7 @@ Each resource is defined by a structure with the following fields:
             <td>path</td>
             <td>the path where the resource should be read from</td>
             <td>it has to follow the <b>type</b> format. for example, if the <b>type</b> is <i>dir</i> (to indicate local directory), then the format should follow how a directory path looks like</td>
-            <td><i>./example/resource/user_account.json</i></td>
+            <td><i>./example/resource</i></td>
         </tr>
         <tr>
             <td rowspan=2>type</td>
@@ -68,13 +68,199 @@ Each resource is defined by a structure with the following fields:
             <td><i>json</i></td>
         </tr>
         <tr>
-            <td rowspan=2>framework_names</td>
+            <td>framework_names</td>
             <td>indicates what frameworks to be executed against a resource. execution of one framework name to another is done <b>sequentially</b> and <b>independently</b>.</td>
-            <td rowspan=2>each framework name should point to an existing framework</td>
-            <td rowspan=2><i>user_account_validation</i></td>
+            <td>each framework name should point to an existing framework</td>
+            <td><i>user_account_validation</i></td>
         </tr>
-        <tr>
-            <td>sequentially means that every resource will be validated and/or evaluated against every framework (indicated by framework name) from top to buttom. independently means that the result of a framework execution against a resource is not carried to the next framework.</td>
-        <tr>
     </tbody>
 </table>
+
+_Note that every field mentioned above is mandatory unless stated otherwise._
+
+## Framework
+
+Framework describes how to validate and/or evaluate a resource and how to return the result. One framework can be used by multiple resources. An example of framework:
+
+```yaml
+...
+frameworks:
+- name: user_account_evaluation
+  schemas:
+  - name: user_account_rule
+    type: file
+    format: json
+    path: ./example/schema/user_account_rule.json
+  definitions:
+  - name: memberships
+    format: json
+    type: dir
+    path: ./example/definition
+    function:
+      type: file
+      path: ./example/procedure/construct_membership_dictionary.jsonnet
+  procedures:
+  - name: enrich_user_account
+    type: file
+    format: jsonnet
+    path: ./example/procedure/enrich_user_account.jsonnet
+  output_targets:
+  - name: std_output
+    type: std
+    format: json
+```
+
+The following is the general constructs for a framework:
+
+Field | Required | Description | Format | Output
+--- | --- | --- | --- | ---
+name | true | defines the name of a particular framework. | it is suggested to be descriptive and needs to follow regex _`[a-z_]+`_ | -
+[schemas](#schema) | false | defines how to validate a resource. | it is an array of `schema` that will be executed _sequentially_ and _independently_.| for each schema, the output of validation is either a success or an error message.
+[definitions](#definition) | false | definitions are data input that might be required by **procedure**. **definitions** helps evaluation to be more efficient when external data is referenced multiple times. | it is an array of `definition` that defines how a definition should be prepared. | for each definition, the output is expected to be an array of JSON object.
+procedures | false | defines how to evaluate a resource. | it is an array of `procedure` that will be executed sequentially with the ability to pass on information from one procedure to the next. | vary, dependig on how the procedure is constructed.
+output_targets | false | defines how an output of validation and/or evaluation should be written out | it is an array of `output_target` that will be executed sequentially and independently. | vary, dependig on the validation and/or evaluation output
+
+### Schema
+
+Schema is mainly used for validation. A schema composes of one or more rules on how a data should look like. Currently, schema only follows the specification by [JSON schema](https://json-schema.org/specification.html). The following is an example of basic construct of a schema in a framework:
+
+```yaml
+...
+name: user_account_rule
+type: file
+format: json
+path: ./example/schema/user_account_rule.json
+...
+```
+
+Field | Description | Format
+--- | --- | ---
+name | the name of schema | it has to be unique within a framework only and should follow _`[a-z_]+`_
+type | the type of data to be read from the path specified by **path** | currently available is `file` only
+format | the format being used to decode the data | currently available is `json` only, pointing that it's a JSON schema
+path | the path where the schema rule to be read from | the valid format based on the **type**
+
+_Note that every field mentioned above is mandatory unless stated otherwise._
+
+And the following is an example of JSON schema, pointed by **path**:
+
+```json
+{
+    "title": "user_account",
+    "description": "Schema to validate user_account.",
+    "type": "object",
+    "properties": {
+        "email": {
+            "type": "string"
+        },
+        "membership_id": {
+            "type": "integer"
+        },
+        "is_active": {
+            "type": "boolean"
+        }
+    },
+    "required": [
+        "email",
+        "membership_id"
+    ],
+    "additionalProperties": false
+}
+```
+
+The above example is a validation rule for data `user_account`, where for every value in its `email` field should be a `string`, its `membership` field should an `integer`, and its `is_active` field should be a boolean. If any of the actual resource (or one could say, record) does not comply, then error will be triggered.
+
+## Definition
+
+Definition is external data that could be used by **procedures**. Definition is usually utilized when one or more procedures want to load one or more externals data once and use it multiple times efficiently. Definition is like a static reference data. An example of definition construct in a framework:
+
+```yaml
+...
+name: memberships
+format: json
+type: dir
+path: ./example/definition
+function:
+    type: file
+    path: ./example/procedure/construct_membership_dictionary.jsonnet
+...
+```
+
+Field | Description | Format | Output
+--- | --- | --- | ---
+name | the name of definition | it has to be unique within a framework only and should follow _`[a-z_]+`_ | -
+type | the type of data to be read from the path specified by **path** | currently available is `file` and `dir` | -
+format | the format being used to decode the data | currently available is `json` and `yaml` | -
+path | the path where to read the actual data from | the valid format based on the **type** | -
+function | an optional instruction to build a definition, where the instruction follows the [Jsonnet format](https://jsonnet.org/) | - | dictionary where the key is the **name** and the value is up to the actual function defined under **function.path**
+function.type | defines the type of path specified by **function.path** | it should be valid for the given **function.path** | -
+function.path | defines the path where to read the actual function | should be valid according to the **function.type** | -
+
+_Note that every field mentioned above is mandatory unless stated otherwise._
+
+As mentionend, every definition **function** should follow [Jsonnet format](https://jsonnet.org/). Apart from that, there are a few additional rules involved when defining a definition:
+
+* the final definition output depends on the **function**:
+  * if **function** is not set, then the actual output will be a dictionary where the key is the definition name and the value is an array
+  * if **function** is set, then the actual output will be a dictionary where the key is the definition name and the value is up to the actual function to define
+* every definition function should define a special Jsonnet function with the following requirement:
+  * it has to be named `construct`
+  * it accepts one parameter
+  * it output one value
+* data being passed as the parameter of Jsonnet function is the raw data, which is an array of definition object
+* definition object is the actual data that is stored in the preferred place, such as a file
+* if the special function requires custom functions, then they should be initialized above the special function
+
+The following is an example of actual definition function:
+
+```jsonnet
+local construct (definitions) = {
+    [std.toString(d.id)]: d
+    for d in definitions
+};
+```
+
+As shown above, there's only one function named `construct`. This is a special function that will be called by Valor, much like a "main" function. If needed, then the user can define some custom functions, like:
+
+```jsonnet
+local custom_function() {
+    // do something
+};
+
+local construct (definitions) = {
+    custom_function(),
+
+    [std.toString(d.id)]: d
+    for d in definitions
+};
+```
+
+The output when the definition function is not set:
+
+```json
+{
+    "memberships": [
+        {
+            "id": 1,
+            "name": "premium",
+            "description": "Membership which involves payment"
+        },
+        ...
+    ]
+}
+```
+
+When the definition function is defined where it outputs an object, then:
+
+```json
+{
+    "memberships": { // the difference
+        {
+            "id": 1,
+            "name": "premium",
+            "description": "Membership which involves payment"
+        },
+        ...
+    }
+}
+```

--- a/docs/recipe.md
+++ b/docs/recipe.md
@@ -1,0 +1,80 @@
+# Recipe
+
+Recipe describes how Valor should execute a pipeline. A pipeline
+is one execution flow of Valor. Each recipe consists of
+one or more **[resources](#resource)** and also
+one or more of its framework **[frameworks](#framework)**.
+
+## Resource
+
+Resource is something to be either validated, evaluated, or both.
+Each recipe should contains one or more resources. An example:
+
+```yaml
+resources: 
+- name: user_account
+  type: file
+  path: ./example/resource/user_account.json
+  format: json
+  framework_names:
+  - user_account_validation
+...
+```
+
+Each resource is defined by a structure with the following fields:
+
+<table>
+    <thead>
+        <tr>
+            <th>Field</th>
+            <th>Description</th>
+            <th>Format</th>
+            <th>Example</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>name</td>
+            <td>a unique name of the resource</td>
+            <td>it is suggested to be descriptive and needs to follow regex <i>[a-z_]+</i></td>
+            <td><i>user_account</i></td>
+        </tr>
+        <tr>
+            <td>path</td>
+            <td>the path where the resource should be read from</td>
+            <td>it has to follow the <b>type</b> format. for example, if the <b>type</b> is <i>dir</i> (to indicate local directory), then the format should follow how a directory path looks like</td>
+            <td><i>./example/resource/user_account.json</i></td>
+        </tr>
+        <tr>
+            <td rowspan=2>type</td>
+            <td rowspan=2>describes the type of path in order to get the resource</td>
+            <td>currently available: <i>file</i> and <i>dir</i></td>
+            <td rowspan=2><i>dir</i></td>
+        </tr>
+        <tr>
+            <td>
+                <ul>
+                    <li>file</li>
+                    describe that the path is of type <i>file</i>. if the <b>path</b> value is actually a directory but the <b>type</b> is set to be a <i>file</i>, then only the first file in that directory will be read.
+                    <li>dir</li>
+                    describe that the path is of type <i>dir</i>. if the <b>path</b> value is not a directory, then error might be returned.
+                </ul>
+            </td>
+        </tr>
+        <tr>
+            <td>format</td>
+            <td>indicates what format a resource was stored</td>
+            <td>currently available: <i>json</i> and <i>yaml</i></td>
+            <td><i>json</i></td>
+        </tr>
+        <tr>
+            <td rowspan=2>framework_names</td>
+            <td>indicates what frameworks to be executed against a resource. execution of one framework name to another is done <b>sequentially</b> and <b>independently</b>.</td>
+            <td rowspan=2>each framework name should point to an existing framework</td>
+            <td rowspan=2><i>user_account_validation</i></td>
+        </tr>
+        <tr>
+            <td>sequentially means that every resource will be validated and/or evaluated against every framework (indicated by framework name) from top to buttom. independently means that the result of a framework execution against a resource is not carried to the next framework.</td>
+        <tr>
+    </tbody>
+</table>

--- a/example/definition/premium.json
+++ b/example/definition/premium.json
@@ -1,0 +1,5 @@
+{
+    "id": 1,
+    "name": "premium",
+    "description": "Membership which involves payment"
+}

--- a/example/definition/standard.json
+++ b/example/definition/standard.json
@@ -1,0 +1,5 @@
+{
+    "id": 0,
+    "name": "standard",
+    "description": "Membership which does not involve payment"
+}

--- a/example/procedure/construct_membership_dictionary.jsonnet
+++ b/example/procedure/construct_membership_dictionary.jsonnet
@@ -1,0 +1,4 @@
+local construct (definitions) = {
+    [std.toString(d.id)]: d
+    for d in definitions
+};

--- a/example/procedure/enrich_user_account.jsonnet
+++ b/example/procedure/enrich_user_account.jsonnet
@@ -1,6 +1,9 @@
-local evaluate(resource, definition, previous) = {
-    email: resource.email,
-    membership: resource.membership,
-    is_active: resource.is_active,
-    is_valid: true
-};
+local evaluate(resource, definition, previous) =
+    local membership_dict = definition['memberships'];
+    local membership_id = std.toString(resource.membership_id);
+    local current_membership = membership_dict[membership_id];
+    {
+        email: resource.email,
+        membership: current_membership.name,
+        is_active: resource.is_active
+    };

--- a/example/resource/lorem.json
+++ b/example/resource/lorem.json
@@ -1,0 +1,5 @@
+{
+    "email": "lorem@ipsum.com",
+    "membership_id": 0,
+    "is_active": false
+}

--- a/example/resource/valor.json
+++ b/example/resource/valor.json
@@ -1,5 +1,5 @@
 {
     "email": "valor@github.com",
-    "membership": "premium",
+    "membership_id": 1,
     "is_active": true
 }

--- a/example/schema/user_account_rule.json
+++ b/example/schema/user_account_rule.json
@@ -6,19 +6,16 @@
         "email": {
             "type": "string"
         },
-        "membership": {
-            "enum": [
-                "standard",
-                "premium"
-            ]
+        "membership_id": {
+            "type": "integer"
         },
         "is_active": {
             "type": "boolean"
         }
     },
     "required": [
-		"email",
-		"membership"
-	],
+        "email",
+        "membership_id"
+    ],
     "additionalProperties": false
 }

--- a/valor.example.yaml
+++ b/valor.example.yaml
@@ -26,6 +26,7 @@ frameworks:
     type: file
     format: jsonnet
     path: ./example/procedure/enrich_user_account.jsonnet
+    output_is_error: false
   output_targets:
   - name: std_output
     type: std

--- a/valor.example.yaml
+++ b/valor.example.yaml
@@ -1,18 +1,26 @@
-resources: 
+resources:
 - name: user_account
-  type: file
-  path: ./example/resource/user_account.json
+  type: dir
+  path: ./example/resource
   format: json
   framework_names:
-  - user_account_validation
+  - user_account_evaluation
 
 frameworks:
-- name: user_account_validation
+- name: user_account_evaluation
   schemas:
   - name: user_account_rule
     type: file
     format: json
     path: ./example/schema/user_account_rule.json
+  definitions:
+  - name: memberships
+    format: json
+    type: dir
+    path: ./example/definition
+    function:
+      type: file
+      path: ./example/procedure/construct_membership_dictionary.jsonnet
   procedures:
   - name: enrich_user_account
     type: file


### PR DESCRIPTION
This PR is intended to add documentation for Valor. The documentation is generally divided into two sections:

* recipe, which explains more about what a recipe is, how to create it, and how it is executed
* command, which explains more about the available commands for Valor

This PR is also related to the issue here  #2 .